### PR TITLE
script for clearDB added

### DIFF
--- a/libs/database/project.json
+++ b/libs/database/project.json
@@ -64,6 +64,14 @@
         "command": "ts-node --project tsconfig.lib.json ../../node_modules/typeorm-extension/dist/cli/index.js seed -d ../../config/orm.config.ts",
         "cwd": "libs/database"
       }
+    },
+    "clear": {
+      "executor": "nx:run-commands",
+      "outputs": [],
+      "options": {
+        "command": "ts-node --project tsconfig.lib.json -r tsconfig-paths/register ./seeders/clearDatabase.ts",
+        "cwd": "backend/database"
+      }
     }
   },
   "tags": []

--- a/libs/database/seeders/clearDatabase.ts
+++ b/libs/database/seeders/clearDatabase.ts
@@ -1,0 +1,26 @@
+import { dataSource } from '../../../config/orm.config';
+
+async function clearDatabase() {
+  await dataSource.initialize();
+
+  const queryRunner = dataSource.createQueryRunner();
+  await queryRunner.startTransaction();
+
+  try {
+    await queryRunner.query('TRUNCATE TABLE "users" CASCADE');
+    await queryRunner.query('TRUNCATE TABLE "clients" CASCADE');
+    await queryRunner.query('TRUNCATE TABLE "pets" CASCADE');
+    await queryRunner.query('TRUNCATE TABLE "appointments" CASCADE');
+    await queryRunner.query('TRUNCATE TABLE "procedure_categories" CASCADE');
+    await queryRunner.query('TRUNCATE TABLE "procedures" CASCADE');
+
+    await queryRunner.commitTransaction();
+  } catch (err) {
+    console.error(err);
+    await queryRunner.rollbackTransaction();
+  } finally {
+    await queryRunner.release();
+  }
+}
+
+clearDatabase().then(() => console.log('Database cleared!'));

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "make:seed": "nx run database:seed",
     "migrate:run": "nx run database:mig-run",
     "migrate:revert": "nx run database:mig-rev",
+    "clear:db": "nx run database:clear",
     "prepare": "husky install"
   },
   "dependencies": {


### PR DESCRIPTION
¿ Que intento mejorar ?

La limpieza de la base de datos a la hora de crear muchos datos con los seeds, con este nuevo comando que agregue basta con hacer `npm run clear:db` desde la raiz del proyecto para eliminar todos los datos de cada tabla.

Espero pueda ser de ayuda, un saludo.